### PR TITLE
Add Features: Export as Batch / Name objects after filenames

### DIFF
--- a/io_mesh_3mf/export_3mf.py
+++ b/io_mesh_3mf/export_3mf.py
@@ -111,16 +111,16 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
 
         global_scale = self.unit_scale(context)
 
-        # Due to an open bug in Python 3.7 (Blender's version) we need to prefix all elements with the namespace.
-        # Bug: https://bugs.python.org/issue17088
-        # Workaround: https://stackoverflow.com/questions/4997848/4999510#4999510
-        root = xml.etree.ElementTree.Element(f"{{{MODEL_NAMESPACE}}}model")
-
-        scene_metadata = Metadata()
-        scene_metadata.retrieve(bpy.context.scene)
-        self.write_metadata(root, scene_metadata)
-
         if self.batch_mode == 'OFF':
+            # Due to an open bug in Python 3.7 (Blender's version) we need to prefix all elements with the namespace.
+            # Bug: https://bugs.python.org/issue17088
+            # Workaround: https://stackoverflow.com/questions/4997848/4999510#4999510
+            root = xml.etree.ElementTree.Element(f"{{{MODEL_NAMESPACE}}}model")
+
+            scene_metadata = Metadata()
+            scene_metadata.retrieve(bpy.context.scene)
+            self.write_metadata(root, scene_metadata)
+
             archive = self.create_archive(self.filepath)
             if archive is None:
                 return {'CANCELLED'}
@@ -138,8 +138,16 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
                 return {'CANCELLED'}
         elif self.batch_mode == 'OBJECT':
             for export_object in blender_objects:
-                prefix = os.path.splitext(self.filepath)[0]
+                # Due to an open bug in Python 3.7 (Blender's version) we need to prefix all elements with the namespace.
+                # Bug: https://bugs.python.org/issue17088
+                # Workaround: https://stackoverflow.com/questions/4997848/4999510#4999510
+                root = xml.etree.ElementTree.Element(f"{{{MODEL_NAMESPACE}}}model")
 
+                scene_metadata = Metadata()
+                scene_metadata.retrieve(bpy.context.scene)
+                self.write_metadata(root, scene_metadata)
+
+                prefix = os.path.splitext(self.filepath)[0]
                 archive = self.create_archive(prefix + bpy.path.clean_name(export_object.name) + ".3mf")
                 if archive is None:
                     return {'CANCELLED'}

--- a/io_mesh_3mf/export_3mf.py
+++ b/io_mesh_3mf/export_3mf.py
@@ -214,8 +214,8 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         """
         scale = self.global_scale
 
-        if context.scene.unit_settings.scale_length != 0:
-            scale *= context.scene.unit_settings.scale_length  # Apply the global scale of the units in Blender.
+        #if context.scene.unit_settings.scale_length != 0:
+        #    scale *= context.scene.unit_settings.scale_length  # Apply the global scale of the units in Blender.
 
         threemf_unit = MODEL_DEFAULT_UNIT
         blender_unit = context.scene.unit_settings.length_unit

--- a/io_mesh_3mf/import_3mf.py
+++ b/io_mesh_3mf/import_3mf.py
@@ -339,8 +339,8 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         """
         scale = self.global_scale
 
-        if context.scene.unit_settings.scale_length != 0:
-            scale /= context.scene.unit_settings.scale_length  # Apply the global scale of the units in Blender.
+        #if context.scene.unit_settings.scale_length != 0:
+        #    scale /= context.scene.unit_settings.scale_length  # Apply the global scale of the units in Blender.
 
         threemf_unit = root.attrib.get("unit", MODEL_DEFAULT_UNIT)
         blender_unit = context.scene.unit_settings.length_unit

--- a/io_mesh_3mf/import_3mf.py
+++ b/io_mesh_3mf/import_3mf.py
@@ -135,6 +135,7 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
                     # information we can.
 
                 path_to_file, filename = os.path.split(path)
+                filename = os.path.splitext(filename)[0]
                 scale_unit = self.unit_scale(context, root)
                 self.resource_objects = {}
                 self.resource_materials = {}


### PR DESCRIPTION
There are 3 essential and very helpful changes in this pull request: 
1. The imported models are named after the file name. This permits an easier identification when importing more than one model at a time
2. The export is extended with the ability to export objects as a batch. Just like the feature while exporting STL files. 
3.  there was a Scaling issue when the length unit was set to mm and the scaling factor to 0.001. Only with these settings the measurements are correct. If one has imported an STL and a 3mf at the same time one of those was out of scale. With this fix both have the correct measurements
