### PR TITLE
Remove Testing, as this is not supported anymore

### DIFF
--- a/io_mesh_3mf/__init__.py
+++ b/io_mesh_3mf/__init__.py
@@ -18,7 +18,6 @@ bl_info = {
     "blender": (2, 80, 0),
     "location": "File > Import-Export",
     "description": "Import-Export 3MF files",
-    "support": 'TESTING',
     "category": "Import-Export"
 }
 


### PR DESCRIPTION
This fix makes it possible to have the extension show up in the latest blender, where testing is no more supported