### PR TITLE
Add force_zip64=True for exporting larger file sizes

### DIFF
--- a/io_mesh_3mf/export_3mf.py
+++ b/io_mesh_3mf/export_3mf.py
@@ -117,7 +117,7 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         self.write_objects(root, resources_element, blender_objects, global_scale)
 
         document = xml.etree.ElementTree.ElementTree(root)
-        with archive.open(MODEL_LOCATION, 'w') as f:
+        with archive.open(MODEL_LOCATION, 'w', force_zip64=True) as f:
             document.write(f, xml_declaration=True, encoding='UTF-8', default_namespace=MODEL_NAMESPACE)
         try:
             archive.close()


### PR DESCRIPTION
Adding the force_zip64 flag set to true on zipfile.open allows writing of larger archives that would otherwise have a size limit exceeded error (example below).

![image](https://github.com/Ghostkeeper/Blender3mfFormat/assets/546458/cf561cac-2b1b-4da9-a0d4-aef61096891b)

I was exporting STL files that were over 2GB in size in Blender to 3MF and was running into the above issue. The python zipfile library has support for larger file sizes with the [force_zip64 ](https://docs.python.org/3/library/zipfile.html) flag. I set it to true and it appears to work properly for handling large file sizes. 