### PR TITLE
testing add-on flag is deprecated in blender 3.5+

### DIFF
--- a/io_mesh_3mf/__init__.py
+++ b/io_mesh_3mf/__init__.py
@@ -18,7 +18,6 @@ bl_info = {
     "blender": (2, 80, 0),
     "location": "File > Import-Export",
     "description": "Import-Export 3MF files",
-    "support": 'TESTING',
     "category": "Import-Export"
 }
 


### PR DESCRIPTION
Fixes installation in blender v3.5 forward