### PR TITLE
Add support for object.name attribute and Color Group in 3MF Materials Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ To install this add-on, currently you need to tell Blender where to find a .zip 
 1. Download the latest release from the [releases page](https://github.com/Ghostkeeper/Blender3mfFormat/releases/latest). This is a .zip archive.
 2. In Blender, go to Edit -> Preferences and open the Add-ons tab on the left.
 3. Click on the Install... button at the top. Navigate to the .zip you downloaded.
-4. Under the "Testing" category, find the add-on called "Import-Export: 3MF format". Make sure that it's enabled. (Note: If searching with the search box, exclude the "Import-Export" text since this is the category, not part of the add-on name. Just search for "3MF" instead.)
+4. Find the add-on called "Import-Export: 3MF format". Make sure that it's enabled. (Note: If searching with the search box, exclude the "Import-Export" text since this is the category, not part of the add-on name. Just search for "3MF" instead.)
+5. If add-on does not show up, manually move `io_mesh_3mf` folder to `C:\Users\%USER%\AppData\Roaming\Blender Foundation\Blender\X.X\scripts\addons` or `C:\Program Files\Blender Foundation\Blender X.X\X.X\scripts\addons` or equivalent for your operating system and reload Blender before enabled in Preferences. 
 
 The add-on is being considered for inclusion in Blender as a community add-on [here](https://developer.blender.org/T84154). This would make it easier to install.
 

--- a/io_mesh_3mf/constants.py
+++ b/io_mesh_3mf/constants.py
@@ -37,8 +37,10 @@ MODEL_MIMETYPE = "application/vnd.ms-package.3dmanufacturing-3dmodel+xml"  # MIM
 
 # Constants in the 3D model file.
 MODEL_NAMESPACE = "http://schemas.microsoft.com/3dmanufacturing/core/2015/02"
+MODEL_MATERIALS_EXTENSION_NAMESPACE = "http://schemas.microsoft.com/3dmanufacturing/material/2015/02"
 MODEL_NAMESPACES = {
-    "3mf": MODEL_NAMESPACE
+    "3mf": MODEL_NAMESPACE,
+    "m": MODEL_MATERIALS_EXTENSION_NAMESPACE
 }
 MODEL_DEFAULT_UNIT = "millimeter"  # If the unit is missing, it will be this.
 


### PR DESCRIPTION
1. Added export support for retaining the object name in the [object.name](https://github.com/3MFConsortium/spec_core/blob/master/3MF%20Core%20Specification.md#chapter-4-object-resources) attribute that is supported for naming individual objects in the GUI of slicers such as Prusaslicer. Cura seems to export object.name set within Cura but not import existing object.name in files.

![image](https://github.com/Ghostkeeper/Blender3mfFormat/assets/546458/10487c73-934b-4987-8865-1a3a8570ac10)

2. Added export support for writing material colors to [Color Group/Color](https://github.com/3MFConsortium/spec_materials/blob/master/3MF%20Materials%20Extension.md#chapter-2-color-groups) from the 3MF Materials and Properties Extension instead of base material. This supports 3MF viewers such as the online 3D preview on Printables.com that support Color Group to display objects in producer specified colors. 

![image](https://github.com/Ghostkeeper/Blender3mfFormat/assets/546458/f44f572f-f95d-4f7e-89b3-a52ed5268f51)

3. Updated README to remove TESTING category. 