### PR TITLE
Fix mesh not loading for 3mf files generated by Bambu Studio

### DIFF
--- a/io_mesh_3mf/import_3mf.py
+++ b/io_mesh_3mf/import_3mf.py
@@ -107,6 +107,10 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
         if bpy.ops.object.select_all.poll():
             bpy.ops.object.select_all(action='DESELECT')  # Deselect other files.
 
+        items_to_build = []
+        self.resource_objects = {}
+        self.resource_materials = {}
+
         for path in paths:
             files_by_content_type = self.read_archive(path)  # Get the files from the archive.
 
@@ -134,12 +138,14 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
                     # information we can.
 
                 scale_unit = self.unit_scale(context, root)
-                self.resource_objects = {}
-                self.resource_materials = {}
                 scene_metadata = self.read_metadata(root, scene_metadata)
                 self.read_materials(root)
                 self.read_objects(root)
-                self.build_items(root, scale_unit)
+
+                items_to_build.append((root, scale_unit))
+            
+        for item_to_build in items_to_build:
+            self.build_items(item_to_build[0], item_to_build[1])
 
         scene_metadata.store(bpy.context.scene)
         annotations.store()


### PR DESCRIPTION
This is to fix an issue with some 3mf files generated by Bambu Studio as described in https://github.com/Ghostkeeper/Blender3mfFormat/issues/69

Basically the `3dmodel.model` file contains references to components defined in other model files. So when it tries to build the build/items the script can't find the sub components in `resource_objects` and logs the error `Build item with unknown resource ID`. Sub components are loaded in `resource_objects` later on but never converted to actual Blender objects.

This fix loads all the models in the 3mf file in `resource_objects` and then creates all the Blender objects. This assumes all the object IDs are unique and I don't know if that's actually the case.

This was tested with the 3mf file here: https://makerworld.com/en/models/20200#profileId-20736

Before the fix:
![image](https://github.com/Ghostkeeper/Blender3mfFormat/assets/16826145/3847f6e1-53a6-40c2-889a-45777313ab4e)

After the fix:
![image](https://github.com/Ghostkeeper/Blender3mfFormat/assets/16826145/11aacf97-6507-4a65-9dda-adb85328ad16)
