### PR TITLE
Fix for Blender 4.4

### DIFF
--- a/io_mesh_3mf/export_3mf.py
+++ b/io_mesh_3mf/export_3mf.py
@@ -68,16 +68,6 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         min=0,
         max=12)
 
-    def __init__(self):
-        """
-        Initialize some fields with defaults before starting.
-        """
-        super().__init__()
-        self.next_resource_id = 1  # Which resource ID to generate for the next object.
-        self.num_written = 0  # How many objects we've written to the file.
-        self.material_resource_id = -1  # We write one material. This is the resource ID of that material.
-        self.material_name_to_index = {}  # For each material in Blender, the index in the 3MF materials group.
-
     def execute(self, context):
         """
         The main routine that writes the 3MF archive.

--- a/io_mesh_3mf/import_3mf.py
+++ b/io_mesh_3mf/import_3mf.py
@@ -60,21 +60,6 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
     directory: bpy.props.StringProperty(subtype='DIR_PATH')
     global_scale: bpy.props.FloatProperty(name="Scale", default=1.0, soft_min=0.001, soft_max=1000.0, min=1e-6, max=1e6)
 
-    def __init__(self):
-        """
-        Initializes the importer with empty fields.
-        """
-        super().__init__()
-        self.resource_objects = {}  # Dictionary mapping resource IDs to ResourceObjects.
-
-        # Dictionary mapping resource IDs to dictionaries mapping indexes to ResourceMaterial objects.
-        self.resource_materials = {}
-
-        # Which of our resource materials already exists in the Blender scene as a Blender material.
-        self.resource_to_material = {}
-
-        self.num_loaded = 0
-
     def execute(self, context):
         """
         The main routine that reads out the 3MF file.


### PR DESCRIPTION
This patch removes the overridden __init__ methods, which are now forbidden (and unnecessary as the execute methods initialize the state themselves.)
