### PR TITLE
Add a note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ The following options are available when exporting to 3MF:
 * Apply modifiers: Apply the modifiers to the mesh data before exporting. This embeds these modifiers permanently in the file. If this is disabled, the unmodified meshes will be saved to the 3MF file instead.
 * Precision: Number of decimals to use for coordinates in the 3MF file. Greater precision will result in a larger file size.
 
+> **Note:**
+> 
+> Exporting as .3MF requires all objects in your Blender project to have a material.
+
+
 Scripting
 ----
 From a script, you can import a 3MF mesh by executing the following function call:


### PR DESCRIPTION
# Add this note to `README.md`

## Reasoning & Context

It just might be me being stupid, but I always forget to give **all** of my object materials, which causes it to export a useless `.3MF` file that doesn't have any geometry data.

If you do export it with this flaw, you will get this error:

```python
Python: Traceback (most recent call last):
  File "/Users/(you)/Library/Application Support/Blender/3.5/scripts/addons/io_mesh_3mf/export_3mf.py", line 115, in execute
    self.material_name_to_index = self.write_materials(resources_element, blender_objects)
  File "/Users/(you)/Library/Application Support/Blender/3.5/scripts/addons/io_mesh_3mf/export_3mf.py", line 220, in write_materials
    material_name = material.name
AttributeError: 'NoneType' object has no attribute 'name'
```

It will export, but only a couple hundred **bytes** will be in there.

So, all in all, **please add this because it will be helpful to new Blender users looking to 3D print their 3D designs.**