### PR TITLE
Bug fixing for Blender 5.0

### DIFF
--- a/io_mesh_3mf/__init__.py
+++ b/io_mesh_3mf/__init__.py
@@ -13,7 +13,7 @@
 bl_info = {
     "name": "3MF format",
     "author": "Ghostkeeper",
-    "version": (1, 0, 2),
+    "version": (1, 0, 3),
     "blender": (2, 80, 0),
     "location": "File > Import-Export",
     "description": "Import-Export 3MF files",

--- a/io_mesh_3mf/export_3mf.py
+++ b/io_mesh_3mf/export_3mf.py
@@ -68,11 +68,12 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         min=0,
         max=12)
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """
         Initialize some fields with defaults before starting.
+        Accepts additional arguments for Blender 5.0 compatibility.
         """
-        super().__init__()
+        super().__init__(*args, **kwargs)
         self.next_resource_id = 1  # Which resource ID to generate for the next object.
         self.num_written = 0  # How many objects we've written to the file.
         self.material_resource_id = -1  # We write one material. This is the resource ID of that material.

--- a/io_mesh_3mf/export_3mf.py
+++ b/io_mesh_3mf/export_3mf.py
@@ -182,14 +182,16 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
         """
         scale = self.global_scale
 
-        if context.scene.unit_settings.scale_length != 0:
-            scale *= context.scene.unit_settings.scale_length  # Apply the global scale of the units in Blender.
+        blender_unit_to_metre = context.scene.unit_settings.scale_length
+        if blender_unit_to_metre == 0:  # Fallback for special cases.
+            blender_unit = context.scene.unit_settings.length_unit
+            blender_unit_to_metre = blender_to_metre[blender_unit]
 
         threemf_unit = MODEL_DEFAULT_UNIT
-        blender_unit = context.scene.unit_settings.length_unit
-        scale /= threemf_to_metre[threemf_unit]  # Convert 3MF units to metre.
-        scale *= blender_to_metre[blender_unit]  # Convert metre to Blender's units.
+        threemf_unit_to_metre = threemf_to_metre[threemf_unit]
 
+        # Compute the scale factor between Blender units and 3MF units.
+        scale *= blender_unit_to_metre / threemf_unit_to_metre
         return scale
 
     def write_materials(self, resources_element, blender_objects):
@@ -276,7 +278,7 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
             item_element.attrib[f"{{{MODEL_NAMESPACE}}}objectid"] = str(objectid)
             mesh_transformation = transformation @ mesh_transformation
             if mesh_transformation != mathutils.Matrix.Identity(4):
-                item_element.attrib[f"{{{MODEL_NAMESPACE}}}transform"] =\
+                item_element.attrib[f"{{{MODEL_NAMESPACE}}}transform"] = \
                     self.format_transformation(mesh_transformation)
 
             metadata = Metadata()

--- a/io_mesh_3mf/export_3mf.py
+++ b/io_mesh_3mf/export_3mf.py
@@ -266,6 +266,9 @@ class Export3MF(bpy.types.Operator, bpy_extras.io_utils.ExportHelper):
 
         build_element = xml.etree.ElementTree.SubElement(root, f"{{{MODEL_NAMESPACE}}}build")
         for blender_object in blender_objects:
+            # Skip objects disabled in renderers
+            if blender_object.hide_render:
+                continue
             if blender_object.parent is not None:
                 continue  # Only write objects that have no parent, since we'll get the child objects recursively.
             if blender_object.type not in {'MESH', 'EMPTY'}:

--- a/io_mesh_3mf/import_3mf.py
+++ b/io_mesh_3mf/import_3mf.py
@@ -60,11 +60,12 @@ class Import3MF(bpy.types.Operator, bpy_extras.io_utils.ImportHelper):
     directory: bpy.props.StringProperty(subtype='DIR_PATH')
     global_scale: bpy.props.FloatProperty(name="Scale", default=1.0, soft_min=0.001, soft_max=1000.0, min=1e-6, max=1e6)
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """
-        Initializes the importer with empty fields.
+        Initialize some fields with defaults before starting.
+        Accepts additional arguments for Blender 5.0 compatibility.
         """
-        super().__init__()
+        super().__init__(*args, **kwargs)
         self.resource_objects = {}  # Dictionary mapping resource IDs to ResourceObjects.
 
         # Dictionary mapping resource IDs to dictionaries mapping indexes to ResourceMaterial objects.


### PR DESCRIPTION
* Arguments for  `__init__` are extended.
*  Fix scale calculation in 3MF export to correctly apply Blender scene units.
* Objects marked with the Disable in renderers flag should be ignored when exporting to 3MF format.